### PR TITLE
(ESPSTUDIO-8126) Update README to clarfiy how we integrate Grafana with sas

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ Here is an example of a Grafana dashboard for an ESP project. This dashboard rel
 
 ## Install a Released Version of the Plug-in
 
-Use the provided installation script to install the plug-in:
+An installation script is provided to install the plugin and configure Grafana. The installation script will modify the Grafana deployment by adding an environment variable to enable the plugin
+and configure a new grafana.ini file to enable UAA authentication.
+
+Grafana will be configured as an OAuth client with the supported OAuth provider (UAA), users of Grafana will be directed to use the OAuth login page.
+
+> **Caution**: Running the installation script might overwrite any existing Grafana configuration
 
 1. Set the correct Kubernetes configuration file for your environment.
    ```
@@ -32,7 +37,6 @@ Use the provided installation script to install the plug-in:
 3. Run the installation script, adjusting the command to specify the following variables:
    - The Kubernetes _namespace_ in which SAS Event Stream Processing is installed.
    - The _version_ of the plug-in that you want to install. Ensure that you specify a version of the plug-in that is compatible with your version of Grafana.
-   > **Caution**: Running the installation script might overwrite any existing Grafana configuration.
 
    ```
    cd ./install

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Use the provided installation script to install the plug-in:
    ```
    export DRYRUN=true
    ```
-4Run the installation script, adjusting the command to specify the following variables:
+4. Run the installation script, adjusting the command to specify the following variables:
    - The Kubernetes _namespace_ in which SAS Event Stream Processing is installed.
    - The _version_ of the plug-in that you want to install. Ensure that you specify a version of the plug-in that is compatible with your version of Grafana.
    > **Caution**: Running the installation script might overwrite any existing Grafana configuration.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here is an example of a Grafana dashboard for an ESP project. This dashboard rel
 ## Install a Released Version of the Plug-in
 
 An installation script is provided to install the plug-in and configure Grafana. The installation script performs the following tasks:
- * Modifies the Grafana deployment by adding the GF_INSTALL_PLUGINS environment variable to enable grafana to install the plug-in.
+ * Modifies the Grafana deployment by adding the GF_INSTALL_PLUGINS environment variable to enable Grafana to install the plug-in.
  * Configures a new `grafana.ini` file to enable OAuth authentication.
  * Configures Grafana as an OAuth client with the supported OAuth provider (UAA). Users of Grafana are directed to use the OAuth login page.
  * Optionally installs Grafana for you.

--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ Here is an example of a Grafana dashboard for an ESP project. This dashboard rel
 
 ## Install a Released Version of the Plug-in
 
-An installation script is provided to install the plugin and configure Grafana. The installation script will modify the Grafana deployment by adding an environment variable to enable the plugin
-and configure a new grafana.ini file to enable UAA authentication.
+An installation script is provided to install the plug-in and configure Grafana, the installation script will:
+ * Modify the Grafana deployment by adding the GF_INSTALL_PLUGINS environment variable to allow grafana to install the plug-in.
+ * Configure a new grafana.ini file to enable OAuth authentication.
+ * Configure Grafana as an OAuth client with the supported OAuth provider (UAA). Users of Grafana are directed to use the OAuth login page.
+ * Optionally install Grafana for you.
 
-Grafana will be configured as an OAuth client with the supported OAuth provider (UAA), users of Grafana will be directed to use the OAuth login page.
-
-> **Caution**: Running the installation script might overwrite any existing Grafana configuration
+Use the provided installation script to install the plug-in:
 
 1. Set the correct Kubernetes configuration file for your environment.
    ```
@@ -33,10 +34,15 @@ Grafana will be configured as an OAuth client with the supported OAuth provider 
 2. (Optional) Set an environment variable to enable the script to install Grafana for you.
    ```
    export INSTALL_GRAFANA=true
+
+3. (Optional) Set an environment variable to run the script as a dry run to see the resulting configuration and apply the settings manually.
    ```
-3. Run the installation script, adjusting the command to specify the following variables:
+   export DRYRUN=true
+   ```
+4Run the installation script, adjusting the command to specify the following variables:
    - The Kubernetes _namespace_ in which SAS Event Stream Processing is installed.
    - The _version_ of the plug-in that you want to install. Ensure that you specify a version of the plug-in that is compatible with your version of Grafana.
+   > **Caution**: Running the installation script might overwrite any existing Grafana configuration.
 
    ```
    cd ./install

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Here is an example of a Grafana dashboard for an ESP project. This dashboard rel
 
 ## Install a Released Version of the Plug-in
 
-An installation script is provided to install the plug-in and configure Grafana, the installation script will:
- * Modify the Grafana deployment by adding the GF_INSTALL_PLUGINS environment variable to allow grafana to install the plug-in.
- * Configure a new grafana.ini file to enable OAuth authentication.
- * Configure Grafana as an OAuth client with the supported OAuth provider (UAA). Users of Grafana are directed to use the OAuth login page.
- * Optionally install Grafana for you.
+An installation script is provided to install the plug-in and configure Grafana. The installation script performs the following tasks:
+ * Modifies the Grafana deployment by adding the GF_INSTALL_PLUGINS environment variable to enable grafana to install the plug-in.
+ * Configures a new `grafana.ini` file to enable OAuth authentication.
+ * Configures Grafana as an OAuth client with the supported OAuth provider (UAA). Users of Grafana are directed to use the OAuth login page.
+ * Optionally installs Grafana for you.
 
-Use the provided installation script to install the plug-in:
+Use the installation script to install the plug-in:
 
 1. Set the correct Kubernetes configuration file for your environment.
    ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Use the installation script to install the plug-in:
 
 3. (Optional) Set an environment variable to run the script as a dry run to see the resulting configuration and apply the settings manually.
    ```
-   export DRYRUN=true
+   export DRY_RUN=true
    ```
 4. Run the installation script, adjusting the command to specify the following variables:
    - The Kubernetes _namespace_ in which SAS Event Stream Processing is installed.

--- a/install/configure-grafana.sh
+++ b/install/configure-grafana.sh
@@ -94,7 +94,7 @@ Deploying Grafana with values:
 EOF
 
 echo "Adding Grafana to allowed OAuth client redirects..."
-#add_grafana_auth_redirect
+add_grafana_auth_redirect
 
 echo "Generating manifests..."
 [ -d "./manifests" ] || mkdir "manifests"


### PR DESCRIPTION
Can we explain 2 things about how the instructions we provide with ow integrate with Grafana:

1) that we register Grafana as OAuth client with whatever provider we are using (SASLogon, UAA, Keycloak) 

So the user will login to Grafana through the SAS OAuth prover.  

2) that the plugin is installed with our scrips by modifying the Grafana deployment in k8s.

Change-Id: I10c4554763915d0154aab019450ab5d79bb6a460