### PR TITLE
(ESPSTUDIO-8275)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Installation scripts are provided to install the plug-in and configure Grafana. 
  * Modify the Grafana deployment by adding the GF_INSTALL_PLUGINS environment variable to enable Grafana to install the plug-in.
  * Configure a new `grafana.ini` file to enable OAuth authentication.
  * Configure Grafana as an OAuth client with the chosen OAuth provider. Users of Grafana are directed to use the OAuth login page.
- * Optionally installs Grafana for you.
+ * Optionally install Grafana for you.
 
 1. Set the correct Kubernetes configuration file for your environment.
    ```

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ This section is relevant only to internal users at SAS.
 ### Install a Released Version of the Plug-in
 
 Installation scripts are provided to install the plug-in and configure Grafana. These scripts perform the following tasks:
- * Modifies the Grafana deployment by adding the GF_INSTALL_PLUGINS environment variable to enable Grafana to install the plug-in.
- * Configures a new `grafana.ini` file to enable OAuth authentication.
- * Configures Grafana as an OAuth client with the chosen OAuth provider. Users of Grafana are directed to use the OAuth login page.
+ * Modify the Grafana deployment by adding the GF_INSTALL_PLUGINS environment variable to enable Grafana to install the plug-in.
+ * Configure a new `grafana.ini` file to enable OAuth authentication.
+ * Configure Grafana as an OAuth client with the chosen OAuth provider. Users of Grafana are directed to use the OAuth login page.
  * Optionally installs Grafana for you.
 
 1. Set the correct Kubernetes configuration file for your environment.
@@ -106,31 +106,31 @@ Installation scripts are provided to install the plug-in and configure Grafana. 
 5. Run `configure-grafana.sh`, adjusting the command to specify the following variables:
    - The Kubernetes _namespace_ in which SAS Event Stream Processing is installed.
    - The _version_ of the plug-in that you want to install. Ensure that you specify a version of the plug-in that is compatible with your version of Grafana.
-   - The _oauth-provider_ of the environment. Select one of the following options: **uaa**, **keycloak** or **viya**.
+   - The _oauth-provider_ of the environment. Select one of the following options: `uaa`, `keycloak` or `viya`.
    > **Caution**: Running the installation script might overwrite any existing Grafana configuration.
 
    ```
    cd ./install
    bash configure-grafana.sh <namespace> <version> <oauth-provider>
    ```
-6. For your chosen OAuth provider run the appropriate script adjusting the command to specify the following variables:
+6. Run one of the following three scripts, depending on your chosen OAuth provider. Adjust the command to specify the following variables.
    - The Kubernetes namespace in which SAS Event Stream Processing is installed, _esp-namespace_.
    - (Optional) The Kubernetes namespace in which Grafana is installed, _grafana-namespace_ if this differs from the namespace in which SAS Event Stream Processing is installed.
-   - ```
+   ```
      bash register-oauth-client-keycloak.sh <esp-namespace> <grafana-namespace>
-     ```
-   - ```
+   ```
+   ```
      bash register-oauth-client-uaa.sh <esp-namespace> <grafana-namespace>
      ```
-   - ```
+   ```
      bash register-oauth-client-viya.sh <esp-namespace> <grafana-namespace>
-     ```
-7. If you have chosen SAS VIYA as your OAuth provider then the Content security policy (CSP) for SAS Logon needs to be altered to allow the Grafana hostname to be used as a target of form submission. 
-If you don't do this, the browser will block the redirect. This can be done in one of two ways.
-   1. Using SAS Environment Manager to update the _content-security-policy_ value under the _sas.commons.web.security_ section.
-   2. Update the _sas-logon-app_ deployment to add the _SAS_COMMONS_WEB_SECURITY_CONTENTSECURITYPOLICY_ environment variable.
+   ```
+7. If your OAuth provider is the SAS Viya platform and Grafana is not running in the same namespace as the SAS Viya platform, you must update the Content Security Policy (CSP) for SAS Logon to allow the Grafana host name to be used as a target of form submission. 
+   If you do not update the CSP, the browser blocks the redirect. You can update the CSP in one of the following two ways:
+   - Use SAS Environment Manager to update the _content-security-policy_ value under the _sas.commons.web.security_ section.
+   - Update the _sas-logon-app_ deployment to add the _SAS_COMMONS_WEB_SECURITY_CONTENTSECURITYPOLICY_ environment variable.
 
-   Update either SAS Environment Manager or the _sas-logon-app_ deployment with the following value, substituting the Grafana hostname, for example:
+   Update either SAS Environment Manager or the _sas-logon-app_ deployment with the following value, substituting the Grafana host name:
    ```
    default-src 'self'; style-src 'self'; font-src 'self' data:;
    frame-ancestors 'self'; form-action 'self' <grafana-host>;

--- a/README.md
+++ b/README.md
@@ -81,13 +81,11 @@ This section is relevant only to internal users at SAS.
 
 ### Install a Released Version of the Plug-in
 
-An installation script is provided to install the plug-in and configure Grafana. The installation script performs the following tasks:
+Installation scripts are provided to install the plug-in and configure Grafana. These scripts perform the following tasks:
  * Modifies the Grafana deployment by adding the GF_INSTALL_PLUGINS environment variable to enable Grafana to install the plug-in.
  * Configures a new `grafana.ini` file to enable OAuth authentication.
  * Configures Grafana as an OAuth client with the chosen OAuth provider. Users of Grafana are directed to use the OAuth login page.
  * Optionally installs Grafana for you.
-
-Use the installation script to install the plug-in:
 
 1. Set the correct Kubernetes configuration file for your environment.
    ```
@@ -105,7 +103,7 @@ Use the installation script to install the plug-in:
    ```
    export GRAFANA_NAMESPACE=grafana
    ```
-5. Run the installation script, adjusting the command to specify the following variables:
+5. Run `configure-grafana.sh`, adjusting the command to specify the following variables:
    - The Kubernetes _namespace_ in which SAS Event Stream Processing is installed.
    - The _version_ of the plug-in that you want to install. Ensure that you specify a version of the plug-in that is compatible with your version of Grafana.
    - The _oauth-provider_ of the environment. Select one of the following options: **uaa**, **keycloak** or **viya**.
@@ -113,8 +111,31 @@ Use the installation script to install the plug-in:
 
    ```
    cd ./install
-   bash configure-grafana.sh <namespace> https://github.com/sassoftware/grafana-esp-plugin/download/<version>/sasesp-plugin-<version>.zip <oauth-provider>
+   bash configure-grafana.sh <namespace> <version> <oauth-provider>
    ```
+6. For your chosen OAuth provider run the appropriate script adjusting the command to specify the following variables:
+   - The Kubernetes namespace in which SAS Event Stream Processing is installed, _esp-namespace_.
+   - (Optional) The Kubernetes namespace in which Grafana is installed, _grafana-namespace_ if this differs from the namespace in which SAS Event Stream Processing is installed.
+   - ```
+     bash register-oauth-client-keycloak.sh <esp-namespace> <grafana-namespace>
+     ```
+   - ```
+     bash register-oauth-client-uaa.sh <esp-namespace> <grafana-namespace>
+     ```
+   - ```
+     bash register-oauth-client-viya.sh <esp-namespace> <grafana-namespace>
+     ```
+7. If you have chosen SAS VIYA as your OAuth provider then the Content security policy (CSP) for SAS Logon needs to be altered to allow the Grafana hostname to be used as a target of form submission. 
+If you don't do this, the browser will block the redirect. This can be done in one of two ways.
+   1. Using SAS Environment Manager to update the _content-security-policy_ value under the _sas.commons.web.security_ section.
+   2. Update the _sas-logon-app_ deployment to add the _SAS_COMMONS_WEB_SECURITY_CONTENTSECURITYPOLICY_ environment variable.
+
+   Update either SAS Environment Manager or the _sas-logon-app_ deployment with the following value, substituting the Grafana hostname, for example:
+   ```
+   default-src 'self'; style-src 'self'; font-src 'self' data:;
+   frame-ancestors 'self'; form-action 'self' <grafana-host>;
+   ```
+
 
 ### (Optional) Build and Install a Privately Signed Version of the Plug-in
 

--- a/install/register-oauth-client-keycloak.sh
+++ b/install/register-oauth-client-keycloak.sh
@@ -59,7 +59,7 @@ function check_requirements() {
 
 # Fetch access token to perform admin tasks:
 function fetch_keycloak_admin_token() {
-    _resp=$(curl "https://${ESP_DOMAIN}/${KEYCLOAK_SUBPATH}/realms/master/protocol/openid-connect/token" -s -k -X POST \
+    _resp=$(curl "https://${ESP_DOMAIN}/${KEYCLOAK_SUBPATH}/realms/master/protocol/openid-connect/token" -k -X POST \
         -H 'Content-Type: application/x-www-form-urlencoded' \
         -H 'Accept: application/json' \
         -d "client_id=admin-cli&grant_type=password&username=${KEYCLOAK_ADMIN}&password=${KEYCLOAK_SECRET}")
@@ -70,7 +70,7 @@ function fetch_keycloak_admin_token() {
 function create_role() {
     _role_name="${1}"
     _role_repr="{\"name\": \"${_role_name}\", \"clientRole\": true}"
-    curl "https://${ESP_DOMAIN}/${KEYCLOAK_SUBPATH}/admin/realms/sas-esp/clients/${_client_id}/roles" -s -k -X POST \
+    curl "https://${ESP_DOMAIN}/${KEYCLOAK_SUBPATH}/admin/realms/sas-esp/clients/${_client_id}/roles" -k -X POST \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer ${_token}" \
         -d "${_role_repr}"
@@ -94,7 +94,7 @@ function add_protocol_mapper() {
        }
     }")
     _mapper_body=$(echo "${_mapper_repr}" | jq -r -c)
-    curl -s -k -X POST \
+    curl -k -X POST \
         "https://${ESP_DOMAIN}/${KEYCLOAK_SUBPATH}/admin/realms/sas-esp/clients/${_client_id}/protocol-mappers/models" \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer ${_token}" \
@@ -104,7 +104,7 @@ function add_protocol_mapper() {
 function prepare_keycloak_roles() {
     _token="$(fetch_keycloak_admin_token)"
     # Get sas-esp realm clients:
-    _kc_clients=$(curl -s -k -X GET "https://${ESP_DOMAIN}/${KEYCLOAK_SUBPATH}/admin/realms/sas-esp/clients" -H "Authorization: Bearer ${_token}")
+    _kc_clients=$(curl -k -X GET "https://${ESP_DOMAIN}/${KEYCLOAK_SUBPATH}/admin/realms/sas-esp/clients" -H "Authorization: Bearer ${_token}")
     # Get OAuth2 Proxy client ID:
     _client_id=$(echo "${_kc_clients}" | jq -r --arg opid "${OAUTH_CLIENT_ID}" '.[] | select(.clientId == $opid) | .id')
     # Create Grafana roles:
@@ -128,7 +128,6 @@ export OAUTH_CLIENT_SECRET
 cat <<EOF
 OAuth details:
   ESP Domain:         ${ESP_DOMAIN}
-  Grafana Domain:      ${GRAFANA_DOMAIN}
   OAuth client ID:     ${OAUTH_CLIENT_ID}
   OAuth client secret: ${OAUTH_CLIENT_SECRET}
 EOF

--- a/install/register-oauth-client-uaa.sh
+++ b/install/register-oauth-client-uaa.sh
@@ -3,6 +3,7 @@
 set -e -o pipefail -o nounset
 
 ESP_NAMESPACE="${1}"
+GRAFANA_NAMESPACE="${2:-${ESP_NAMESPACE}}"
 OAUTH_CLIENT_ID="${OAUTH_CLIENT_ID:-sv_client}"; export OAUTH_CLIENT_ID
 OAUTH_CLIENT_SECRET="${OAUTH_CLIENT_SECRET:-secret}"; export OAUTH_CLIENT_SECRET
 
@@ -21,10 +22,11 @@ function usage () {
 }
 
 ESP_DOMAIN=$(kubectl -n "${ESP_NAMESPACE}" get ingress --output json | jq -r '.items[0].spec.rules[0].host')
+GRAFANA_DOMAIN=$(kubectl -n "${GRAFANA_NAMESPACE}" get ingress --output json | jq -r '.items[0].spec.rules[0].host')
 
 # Fetch access token to perform admin tasks:
 function fetch_uaa_admin_token() {
-    _resp=$(curl "https://${ESP_DOMAIN}/uaa/oauth/token" -s -k -X POST \
+    _resp=$(curl "https://${ESP_DOMAIN}/uaa/oauth/token" -k -X POST \
         -H 'Content-Type: application/x-www-form-urlencoded' \
         -H 'Accept: application/json' \
         -d "client_id=${UAA_ADMIN}&client_secret=${UAA_SECRET}&grant_type=client_credentials&response_type=token")
@@ -35,14 +37,14 @@ function fetch_uaa_admin_token() {
 # Add Grafana generic OAuth to allowed auth redirects:
 function add_grafana_auth_redirect_uaa() {
     _token="$(fetch_uaa_admin_token)"
-    _redirect="https://${ESP_DOMAIN}/grafana/login/generic_oauth"
+    _redirect="https://${GRAFANA_DOMAIN}/grafana/login/generic_oauth"
 
-    _config=$(curl -s -k -X GET "https://${ESP_DOMAIN}/uaa/oauth/clients/${OAUTH_CLIENT_ID}" -H "Authorization: Bearer ${_token}")
+    _config=$(curl -k -X GET "https://${ESP_DOMAIN}/uaa/oauth/clients/${OAUTH_CLIENT_ID}" -H "Authorization: Bearer ${_token}")
 
     _update_body=$(echo "${_config}" | jq -c -r --arg redirect "${_redirect}" \
         '.redirect_uri += [$redirect] | {client_id: .client_id, redirect_uri: .redirect_uri}')
 
-    _resp=$(curl "https://${ESP_DOMAIN}/uaa/oauth/clients/${OAUTH_CLIENT_ID}" -s -k -X PUT \
+    _resp=$(curl "https://${ESP_DOMAIN}/uaa/oauth/clients/${OAUTH_CLIENT_ID}" -k -X PUT \
         -o /dev/null -w "%{http_code}" \
         -H 'Content-Type: application/json' \
         -H "Authorization: Bearer ${_token}" \

--- a/install/register-oauth-client-uaa.sh
+++ b/install/register-oauth-client-uaa.sh
@@ -2,6 +2,26 @@
 
 set -e -o pipefail -o nounset
 
+ESP_NAMESPACE="${1}"
+OAUTH_CLIENT_ID="${OAUTH_CLIENT_ID:-sv_client}"; export OAUTH_CLIENT_ID
+OAUTH_CLIENT_SECRET="${OAUTH_CLIENT_SECRET:-secret}"; export OAUTH_CLIENT_SECRET
+
+function usage () {
+    echo "Usage: ${0} <esp-namespace> " >&2
+    exit 1
+}
+
+[ -z "$KUBECONFIG" ] && {
+    echo "KUBECONFIG environment variable unset." >&2
+    exit 1
+}
+
+[ -z "${ESP_NAMESPACE}" ] && {
+    usage
+}
+
+ESP_DOMAIN=$(kubectl -n "${ESP_NAMESPACE}" get ingress --output json | jq -r '.items[0].spec.rules[0].host')
+
 # Fetch access token to perform admin tasks:
 function fetch_uaa_admin_token() {
     _resp=$(curl "https://${ESP_DOMAIN}/uaa/oauth/token" -s -k -X POST \
@@ -42,5 +62,15 @@ UAA_ADMIN=$(echo "${_uaa_secret_data}" | jq -r '.data.username | @base64d')
 export UAA_ADMIN
 UAA_SECRET=$(echo "${_uaa_secret_data}" | jq -r '.data.password | @base64d')
 export UAA_SECRET
+
+cat <<EOF
+OAuth details:
+  ESP Domain:         ${ESP_DOMAIN}
+  Grafana Domain:      ${GRAFANA_DOMAIN}
+  OAuth client ID:     ${OAUTH_CLIENT_ID}
+  OAuth client secret: ${OAUTH_CLIENT_SECRET}
+  UAA Admin:     ${UAA_ADMIN}
+  UAA secret: ${UAA_SECRET}
+EOF
 
 add_grafana_auth_redirect_uaa


### PR DESCRIPTION
Plugin deployment option for different namespaces on Viya

Update readme to reflect that the scripts are now run seperate configure-grafana.sh and then the appropriate register-oauth-client-*.sh

no longer need to provide the whole plugin url, just the version

Change-Id: Iab2ab7cc80ddb6c9abc717f28eddc37a0a2d41c6