### PR TITLE
fix: Grafana plugin does not refresh keycloak access tokens

### DIFF
--- a/docker/dev/config/kc3_config.ini
+++ b/docker/dev/config/kc3_config.ini
@@ -22,6 +22,7 @@ auto_assign_org = true
 auto_assign_org_role = Admin
 
 [auth.generic_oauth]
+use_refresh_token = true
 enabled = true
 tls_skip_verify_insecure = true
 name = SASLogon

--- a/docker/dev/config/kc5-esplight_config.ini
+++ b/docker/dev/config/kc5-esplight_config.ini
@@ -23,6 +23,7 @@ disable_login_form = true
 signout_redirect_url = https://esplight.ingress-nginx.espsc-kc5-m1.espstudio.sashq-d.openstack.sas.com/oauth2/sign_out?rd=https://esplight.ingress-nginx.espsc-kc5-m1.espstudio.sashq-d.openstack.sas.com/uaa/logout.do?redirect=https://esplight.ingress-nginx.espsc-kc5-m1.espstudio.sashq-d.openstack.sas.com/uaa/login
 
 [auth.generic_oauth]
+use_refresh_token = true
 tls_skip_verify_insecure = true
 enabled = true
 name = OAuth

--- a/install/config-map.yaml
+++ b/install/config-map.yaml
@@ -29,6 +29,7 @@ data:
     signout_redirect_url = TEMPLATE_SIGNOUT_REDIRECT_URL
 
     [auth.generic_oauth]
+    use_refresh_token = true
     tls_skip_verify_insecure = true
     enabled = true
     name = OAuth


### PR DESCRIPTION
update installation to set use_refresh_token = true improve error messages to client